### PR TITLE
docs: fix nf-core pipeline component sentence

### DIFF
--- a/docs/session_1/3_configuration.md
+++ b/docs/session_1/3_configuration.md
@@ -18,8 +18,7 @@ Nextflow DSL2 <span style="color:#087f5b;">**workflows**</span> are built up of 
 <p align="left"><img src="../../images/1_3_structure.excalidraw.png" alt="nf-core pipeline file structure" width="400"/></p> 
 <br>
 
-Most nf-core pipelines consist of combination of <span style="color:#c92a2a;">**subworkflows**</span> and <span style="color:#364fc7;">**modules**</span>.
-a single <span style="color:#087f5b;">**workflow**</span> file (there are a few exceptions). This is the main `<workflow>.nf` file that is used to bring everything else together. Instead of having one large monolithic script, it is broken up into a combination of <span style="color:#c92a2a;">**subworkflows**</span> and <span style="color:#364fc7;">**modules**</span>.
+Most nf-core pipelines consist of a combination of <span style="color:#c92a2a;">**subworkflows**</span>, <span style="color:#364fc7;">**modules**</span>, and a single <span style="color:#087f5b;">**workflow**</span> file (there are a few exceptions). This is the main `<workflow>.nf` file that is used to bring everything else together. Instead of having one large monolithic script, it is broken up into a combination of <span style="color:#c92a2a;">**subworkflows**</span> and <span style="color:#364fc7;">**modules**</span>.
 <br>
 <p align="center"><img src="../../images/1_3_worksubmod.excalidraw.png" alt="scaffolding of nf-core pipeline" width="900"/></p> 
 <br>


### PR DESCRIPTION
Fixes #15

Changes:
- `Most nf-core pipelines consist of combination of <span style="color:#c92a2a;">**subworkflows**</span> and <span style="color:#364fc7;">**modules**</span>.
a single <span style="color:#087f5b;">**workflow**</span> file (there are a few exceptions).` -> `Most nf-core pipelines consist of a combination of <span style="color:#c92a2a;">**subworkflows**</span>, <span style="color:#364fc7;">**modules**</span>, and a single <span style="color:#087f5b;">**workflow**</span> file (there are a few exceptions).` in `docs/session_1/3_configuration.md` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Verified no duplicate open PR was found for the referenced issue number(s) before opening this PR.
